### PR TITLE
Fix preview URL in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,4 +12,4 @@
 
 -   `npm run build` - Builds for production, emitting to `dist/`
 
--   `npm run preview` - Starts a server at http://localhost:4173/ to test production build locally
+-   `npm run preview` - Starts a server at <http://localhost:4173/> to test production build locally


### PR DESCRIPTION
## Summary
- correct the preview server URL

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f67e8cdf0832cae6b9d51525bf103