### PR TITLE
Fix README heading

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,6 @@
-# `create-preact`
+# bookclub-client
+
+A simple frontend application for managing a book club using Preact and Vite.
 
 <h2 align="center">
   <img height="256" width="256" src="./src/assets/preact.svg">


### PR DESCRIPTION
## Summary
- rename main heading to `bookclub-client`
- add a short description

## Testing
- `npm run test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_683f68016848832c979cc83b39944aaf